### PR TITLE
feature/recommended-fe-be 사용자 맞춤 여행지 추천 로직 수정 및 여행지 세부정보 view 수정

### DIFF
--- a/src/main/java/com/nevigo/ai_navigo/controller/recommendedController.java
+++ b/src/main/java/com/nevigo/ai_navigo/controller/recommendedController.java
@@ -1,292 +1,373 @@
-//package com.nevigo.ai_navigo.controller;
-//
-//import com.nevigo.ai_navigo.dto.MemberDTO;
-//import com.nevigo.ai_navigo.dto.UserClickDTO;
-//import com.nevigo.ai_navigo.service.IF_preferenceService;
-//import jakarta.servlet.http.HttpSession;
-//import lombok.RequiredArgsConstructor;
-//import org.json.JSONArray;
-//import org.json.JSONObject;
-//import org.springframework.http.*;
-//import org.springframework.stereotype.Controller;
-//import org.springframework.ui.Model;
-//import org.springframework.web.bind.annotation.GetMapping;
-//import org.springframework.web.bind.annotation.PostMapping;
-//import org.springframework.web.bind.annotation.RequestBody;
-//import org.springframework.web.bind.annotation.RequestParam;
-//import org.springframework.web.client.RestTemplate;
-//import org.springframework.web.util.UriComponentsBuilder;
-//
-//import java.net.URI;
-//import java.nio.charset.StandardCharsets;
-//
-//@Controller
-//@RequiredArgsConstructor
-//public class recommendedController {
-//
-//    private final IF_preferenceService ifPreferenceService;
-//    private final RestTemplate restTemplate = new RestTemplate();
-//
-//    // FastAPI URL
-//    private static final String FASTAPI_URL = "http://127.0.0.1:5000/recommend/";
-//
-//    // 공공데이터 API 기본 URL (마지막의 '?' 제거)
-//    private static final String BASE_API_URL = "http://apis.data.go.kr/B551011/KorService1/areaBasedList1";
-//    private static final String BASE_API_URL_COMMON = "http://apis.data.go.kr/B551011/KorService1/detailCommon1";
-//
-//    // 이미 URL 인코딩된 키(포털에서 제공된 Encoding 버전) 사용하거나,
-//    // 디코딩된 상태라면 별도 URLEncoder.encode(...) 하지 않음
-//    // 예: 인코딩된 값: "zEp9kLeLZiXElh6mddTl2DXHIl44C4brxSyQojUBO6zjiy25apv9Dvh00sygk%2BKzMuXzMv3zKpoylWiGbVlCLA%3D%3D"
-//    // 또는 디코딩된 값: "zEp9kLeLZiXElh6mddTl2DXHIl44C4brxSyQojUBO6zjiy25apv9Dvh00sygk+KzMuXzMv3zKpoylWiGbVlCLA=="
-//    // [예시] 이미 인코딩된 값 그대로 사용:
-//    private static final String SERVICE_KEY = "zEp9kLeLZiXElh6mddTl2DXHIl44C4brxSyQojUBO6zjiy25apv9Dvh00sygk%2BKzMuXzMv3zKpoylWiGbVlCLA%3D%3D";
-//    // 만약 디코딩된 키라면 이렇게 설정:
-//    // private static final String SERVICE_KEY = "zEp9kLeLZiXElh6mddTl2DXHIl44C4brxSyQojUBO6zjiy25apv9Dvh00sygk+KzMuXzMv3zKpoylWiGbVlCLA==";
-//
-//    @GetMapping("/main/recommended")
-//    public String recommendedController(HttpSession session, Model model) {
-//        // 세션 체크
-//        MemberDTO member = (MemberDTO) session.getAttribute("memberInfo");
-//        if (member == null) {
-//            System.out.println("❌ [recommendedController] 세션에 memberInfo 없음 → 메인 페이지로");
-//            return "redirect:/main";
-//        }
-//        String memberId = member.getMemberId();
-//        System.out.println("✅ [recommendedController] 로그인된 memberId: " + memberId);
-//
-//        // FastAPI 호출
-//        String recommendedCat3 = callFastAPI(memberId);
-//        if (recommendedCat3 == null) {
-//            System.out.println("❌ [recommendedController] recommendedCat3 = null");
-//            model.addAttribute("items", new JSONArray());
-//            return "/recommended/recommended";
-//        }
-//
-//        // 공공데이터 API 호출
-//        try {
-//            // 1) UriComponentsBuilder 사용
-//            //    .build(true) → 이미 인코딩된 파라미터를 추가 인코딩하지 않음
-//            //    (또는 디코딩된 키라면 builder가 자동 인코딩)
-//            URI uri = UriComponentsBuilder
-//                    .fromHttpUrl(BASE_API_URL)
-//                    .queryParam("serviceKey", SERVICE_KEY)
-//                    .queryParam("numOfRows", 9)
-//                    .queryParam("pageNo", 1)
-//                    .queryParam("MobileOS", "ETC")
-//                    .queryParam("MobileApp", "AppTest")
-//                    .queryParam("_type", "json")
-//                    .queryParam("listYN", "Y")
-//                    .queryParam("arrange", "R")
-//                    .queryParam("cat3", recommendedCat3)
-//                    .build(true)   // true → 기존 파라미터 그대로 (중복 인코딩X)
-//                    .toUri();
-//
-//            System.out.println("✅ [recommendedController] 최종 요청 URI: " + uri);
-//
-//            // 2) 헤더 설정
-//            HttpHeaders headers = new HttpHeaders();
-//            headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
-//            headers.set("User-Agent", "Mozilla/5.0");
-//
-//            HttpEntity<?> entity = new HttpEntity<>(headers);
-//
-//            // 3) 실제 요청
-//            ResponseEntity<String> response = restTemplate.exchange(
-//                    uri,
-//                    HttpMethod.GET,
-//                    entity,
-//                    String.class
-//            );
-//
-//            // 4) 응답 파싱
-//            System.out.println("✅ [recommendedController] 응답 상태: " + response.getStatusCode());
-//            System.out.println("✅ [recommendedController] 응답 헤더: " + response.getHeaders());
-//            String responseBody = response.getBody();
-//            System.out.println("✅ [recommendedController] 응답 바디: " + responseBody);
-//
-//            if (response.getStatusCode() == HttpStatus.OK && responseBody != null) {
-//                JSONObject jsonObj = new JSONObject(responseBody);
-//
-//                if (jsonObj.has("response")) {
-//                    JSONObject respObj = jsonObj.getJSONObject("response");
-//                    if (respObj.has("body")
-//                            && respObj.getJSONObject("body").has("items")
-//                            && respObj.getJSONObject("body").getJSONObject("items").has("item")) {
-//
-//                        JSONArray items = respObj
-//                                .getJSONObject("body")
-//                                .getJSONObject("items")
-//                                .getJSONArray("item");
-//                        model.addAttribute("items", items);
-//                    } else {
-//                        System.out.println("❌ [recommendedController] 'item' 배열 없음.");
-//                        model.addAttribute("items", new JSONArray());
-//                    }
-//                } else {
-//                    System.out.println("❌ [recommendedController] 'response' 키 없음.");
-//                    model.addAttribute("items", new JSONArray());
-//                }
-//            } else {
-//                System.out.println("❌ [recommendedController] 응답 코드 200이 아니거나 바디가 null");
-//                model.addAttribute("items", new JSONArray());
-//            }
-//        } catch (Exception e) {
-//            System.out.println("❌ [recommendedController] 공공데이터 API 오류: " + e.getMessage());
-//            e.printStackTrace();
-//            model.addAttribute("items", new JSONArray());
-//        }
-//
-//        return "/recommended/recommended";
-//    }
-//
-//    /**
-//     * FastAPI 호출 (AI 추천)
-//     */
-//    private String callFastAPI(String memberId) {
-//        String url = FASTAPI_URL + memberId;
-//        System.out.println("✅ [callFastAPI] FastAPI 호출 URL: " + url);
-//
-//        try {
-//            HttpHeaders headers = new HttpHeaders();
-//            headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
-//            headers.set("User-Agent", "Mozilla/5.0");
-//
-//            HttpEntity<?> entity = new HttpEntity<>(headers);
-//
-//            ResponseEntity<String> response = restTemplate.exchange(
-//                    url,
-//                    HttpMethod.GET,
-//                    entity,
-//                    String.class
-//            );
-//
-//            System.out.println("✅ [callFastAPI] 응답 상태: " + response.getStatusCode());
-//            System.out.println("✅ [callFastAPI] 응답 헤더: " + response.getHeaders());
-//            System.out.println("✅ [callFastAPI] 응답 바디: " + response.getBody());
-//
-//            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
-//                JSONObject jsonResponse = new JSONObject(response.getBody());
-//                return jsonResponse.optString("cat3", null);
-//            }
-//        } catch (Exception e) {
-//            System.out.println("❌ [callFastAPI] FastAPI 오류: " + e.getMessage());
-//            e.printStackTrace();
-//        }
-//        return null;
-//    }
-//
-//    @GetMapping("main/recommend/detail")
-//    public String detailController(@RequestParam("contentid") String contentid,
-//                                   @RequestParam("contenttypeid") String contenttypeid,
-//                                   HttpSession session, Model model)
-//            throws Exception {
-//
-//
-//        // 세션 체크
-//        MemberDTO member = (MemberDTO) session.getAttribute("memberInfo");
-//        if (member == null) {
-//            System.out.println("❌ [recommendedController] 세션에 memberInfo 없음 → 메인 페이지로");
-//            return "redirect:/main";
-//        }
-//
-//        String memberId = member.getMemberId();
-//        System.out.println("✅ [recommendedController] 로그인된 memberId: " + memberId);
-//
-//        //공공 데이터 API 호출
-//        try {
-//            URI uri = UriComponentsBuilder
-//                    .fromHttpUrl(BASE_API_URL_COMMON)
-//                    .queryParam("serviceKey", SERVICE_KEY)
-//                    .queryParam("MobileOS", "ETC")
-//                    .queryParam("MobileApp", "AppTest")
-//                    .queryParam("_type", "json")
-//                    .queryParam("contentId", contentid)
-//                    .queryParam("defaultYN", "Y")
-//                    .queryParam("firstImageYN", "Y")
-//                    .queryParam("areacodeYN", "Y")
-//                    .queryParam("catcodeYN", "Y")
-//                    .queryParam("addrinfoYN", "Y")
-//                    .queryParam("mapinfoYN", "Y")
-//                    .queryParam("overviewYN", "Y")
-//                    .build(true) // true -> 기존 파라미터 그대로 (중복인코딩x)
-//                    .toUri();
-//            System.out.println("detailController 요청 URI:  " + uri);
-//
-//            //2. header 설정
-//            HttpHeaders headers = new HttpHeaders();
-//            headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
-//            headers.set("User-Agent", "Mozilla/5.0");
-//
-//            HttpEntity<?> entity = new HttpEntity<>(headers);
-//
-//            //3. 요청
-//            ResponseEntity<String> response = restTemplate.exchange(
-//                    uri,
-//                    HttpMethod.GET,
-//                    entity,
-//                    String.class
-//            );
-//
-//            //4. 응답 파싱
-////            response.getStatusCode();
-////            response.getHeaders();
-////            response.getBody();
-//            System.out.println("✅ [recommendedController] 응답 상태: " + response.getStatusCode());
-//            System.out.println("✅ [recommendedController] 응답 헤더: " + response.getHeaders());
-//            String responseBody = response.getBody();
-//            System.out.println("✅ [recommendedController] 응답 바디: " + responseBody);
-//
-//            if (response.getStatusCode() == HttpStatus.OK && responseBody != null) {
-//                JSONObject jsonObj = new JSONObject(responseBody);
-//
-//                if (jsonObj.has("response")) {
-//                    JSONObject respObj = jsonObj.getJSONObject("response");
-//                    if (respObj.has("body")
-//                            && respObj.getJSONObject("body").has("items")
-//                            && respObj.getJSONObject("body").getJSONObject("items").has("item")) {
-//
-//                        JSONArray items = respObj
-//                                .getJSONObject("body")
-//                                .getJSONObject("items")
-//                                .getJSONArray("item");
-//                        model.addAttribute("items", items);
-//                        System.out.println("✅ respone 완료 후 model에 items 추가");
-//                    } else {
-//                        System.out.println("❌ [recommendedController] 'item' 배열 없음.");
-//                        model.addAttribute("items", new JSONArray());
-//                    }
-//                } else {
-//                    System.out.println("❌ [recommendedController] 'response' 키 없음.");
-//                    model.addAttribute("items", new JSONArray());
-//                }
-//            } else {
-//                System.out.println("❌ [recommendedController] 응답 코드 200이 아니거나 바디가 null");
-//                model.addAttribute("items", new JSONArray());
-//            }
-//
-//        } catch (Exception e) {
-//            System.out.println("❌ [recommendedController] 공공데이터 API 오류: " + e.getMessage());
-//            e.printStackTrace();
-//            model.addAttribute("items", new JSONArray());
-//        }
-//
-//
-//        return "/recommended/detail";
-//    }
-//
-//    @PostMapping("/recordClick")
-//    public ResponseEntity<String> recordUserClick(
-//            HttpSession session,
-//            @RequestBody UserClickDTO userClickDTO
-//    ) throws Exception {
-//        MemberDTO member = (MemberDTO) session.getAttribute("memberInfo");
-//        if (member != null) {
-//            String memberId = member.getMemberId();
-//            userClickDTO.setMember_id(memberId);
-//            ifPreferenceService.clickTravelOne(userClickDTO);
-//            System.out.println("[recordClick] " + userClickDTO);
-//            return ResponseEntity.ok("Click recorded");
-//        }
-//        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("User not logged in");
-//    }
-//}
+package com.nevigo.ai_navigo.controller;
+
+import com.nevigo.ai_navigo.dto.MemberDTO;
+import com.nevigo.ai_navigo.dto.UserClickDTO;
+import com.nevigo.ai_navigo.service.IF_preferenceService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.http.*;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+@Controller
+@RequiredArgsConstructor
+public class recommendedController {
+
+    private final IF_preferenceService ifPreferenceService;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // FastAPI URL
+    private static final String FASTAPI_URL = "http://127.0.0.1:5000/recommend/";
+
+    // 공공데이터 API 기본 URL (마지막의 '?' 제거)
+    private static final String BASE_API_URL = "http://apis.data.go.kr/B551011/KorService1/areaBasedList1";
+    private static final String BASE_API_URL_COMMON = "http://apis.data.go.kr/B551011/KorService1/detailCommon1";
+    private static final String BASE_API_URL_DETAIL = "http://apis.data.go.kr/B551011/KorService1/detailIntro1";
+    private static final String BASE_API_URL_DETAILIMAGE = "http://apis.data.go.kr/B551011/KorService1/detailImage1";
+
+
+    // 이미 URL 인코딩된 키(포털에서 제공된 Encoding 버전) 사용하거나,
+    // 디코딩된 상태라면 별도 URLEncoder.encode(...) 하지 않음
+    // 예: 인코딩된 값: "zEp9kLeLZiXElh6mddTl2DXHIl44C4brxSyQojUBO6zjiy25apv9Dvh00sygk%2BKzMuXzMv3zKpoylWiGbVlCLA%3D%3D"
+    // 또는 디코딩된 값: "zEp9kLeLZiXElh6mddTl2DXHIl44C4brxSyQojUBO6zjiy25apv9Dvh00sygk+KzMuXzMv3zKpoylWiGbVlCLA=="
+    // [예시] 이미 인코딩된 값 그대로 사용:
+    private static final String SERVICE_KEY = "zEp9kLeLZiXElh6mddTl2DXHIl44C4brxSyQojUBO6zjiy25apv9Dvh00sygk%2BKzMuXzMv3zKpoylWiGbVlCLA%3D%3D";
+    // 만약 디코딩된 키라면 이렇게 설정:
+    // private static final String SERVICE_KEY = "zEp9kLeLZiXElh6mddTl2DXHIl44C4brxSyQojUBO6zjiy25apv9Dvh00sygk+KzMuXzMv3zKpoylWiGbVlCLA==";
+
+    @GetMapping("/main/recommended")
+    public String recommendedController(HttpSession session, Model model) {
+        // 세션 체크
+        MemberDTO member = (MemberDTO) session.getAttribute("memberInfo");
+        if (member == null) {
+            System.out.println("❌ [recommendedController] 세션에 memberInfo 없음 → 메인 페이지로");
+            return "redirect:/main";
+        }
+        String memberId = member.getMemberId();
+        System.out.println("✅ [recommendedController] 로그인된 memberId: " + memberId);
+
+        // FastAPI 호출
+        String recommendedCat3 = callFastAPI(memberId);
+        if (recommendedCat3 == null) {
+            System.out.println("❌ [recommendedController] recommendedCat3 = null");
+            model.addAttribute("items", new JSONArray());
+            return "/recommended/recommended";
+        }
+
+        // 공공데이터 API 호출
+        try {
+            // 1) UriComponentsBuilder 사용
+            //    .build(true) → 이미 인코딩된 파라미터를 추가 인코딩하지 않음
+            //    (또는 디코딩된 키라면 builder가 자동 인코딩)
+            URI uri = UriComponentsBuilder
+                    .fromHttpUrl(BASE_API_URL)
+                    .queryParam("serviceKey", SERVICE_KEY)
+                    .queryParam("numOfRows", 9)
+                    .queryParam("pageNo", 1)
+                    .queryParam("MobileOS", "ETC")
+                    .queryParam("MobileApp", "AppTest")
+                    .queryParam("_type", "json")
+                    .queryParam("listYN", "Y")
+                    .queryParam("arrange", "R")
+                    .queryParam("cat3", recommendedCat3)
+                    .build(true)   // true → 기존 파라미터 그대로 (중복 인코딩X)
+                    .toUri();
+
+            System.out.println("✅ [recommendedController] 최종 요청 URI: " + uri);
+
+            // 2) 헤더 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+            headers.set("User-Agent", "Mozilla/5.0");
+
+            HttpEntity<?> entity = new HttpEntity<>(headers);
+
+            // 3) 실제 요청
+            ResponseEntity<String> response = restTemplate.exchange(
+                    uri,
+                    HttpMethod.GET,
+                    entity,
+                    String.class
+            );
+
+            // 4) 응답 파싱
+            System.out.println("✅ [recommendedController] 응답 상태: " + response.getStatusCode());
+            System.out.println("✅ [recommendedController] 응답 헤더: " + response.getHeaders());
+            String responseBody = response.getBody();
+            System.out.println("✅ [recommendedController] 응답 바디: " + responseBody);
+
+            if (response.getStatusCode() == HttpStatus.OK && responseBody != null) {
+                JSONObject jsonObj = new JSONObject(responseBody);
+
+                if (jsonObj.has("response")) {
+                    JSONObject respObj = jsonObj.getJSONObject("response");
+                    if (respObj.has("body")
+                            && respObj.getJSONObject("body").has("items")
+                            && respObj.getJSONObject("body").getJSONObject("items").has("item")) {
+
+                        JSONArray items = respObj
+                                .getJSONObject("body")
+                                .getJSONObject("items")
+                                .getJSONArray("item");
+                        model.addAttribute("items", items);
+                    } else {
+                        System.out.println("❌ [recommendedController] 'item' 배열 없음.");
+                        model.addAttribute("items", new JSONArray());
+                    }
+                } else {
+                    System.out.println("❌ [recommendedController] 'response' 키 없음.");
+                    model.addAttribute("items", new JSONArray());
+                }
+            } else {
+                System.out.println("❌ [recommendedController] 응답 코드 200이 아니거나 바디가 null");
+                model.addAttribute("items", new JSONArray());
+            }
+        } catch (Exception e) {
+            System.out.println("❌ [recommendedController] 공공데이터 API 오류: " + e.getMessage());
+            e.printStackTrace();
+            model.addAttribute("items", new JSONArray());
+        }
+
+        return "/recommended/recommended";
+    }
+
+    /**
+     * FastAPI 호출 (AI 추천)
+     */
+    private String callFastAPI(String memberId) {
+        String url = FASTAPI_URL + memberId;
+        System.out.println("✅ [callFastAPI] FastAPI 호출 URL: " + url);
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+            headers.set("User-Agent", "Mozilla/5.0");
+
+            HttpEntity<?> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    String.class
+            );
+
+            System.out.println("✅ [callFastAPI] 응답 상태: " + response.getStatusCode());
+            System.out.println("✅ [callFastAPI] 응답 헤더: " + response.getHeaders());
+            System.out.println("✅ [callFastAPI] 응답 바디: " + response.getBody());
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                JSONObject jsonResponse = new JSONObject(response.getBody());
+                return jsonResponse.optString("cat3", null);
+            }
+        } catch (Exception e) {
+            System.out.println("❌ [callFastAPI] FastAPI 오류: " + e.getMessage());
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @GetMapping("main/recommend/detail")
+    public String detailController(@RequestParam("contentid") String contentid,
+                                   @RequestParam("contenttypeid") String contenttypeid,
+                                   HttpSession session, Model model)
+            throws Exception {
+
+
+        // 세션 체크
+        MemberDTO member = (MemberDTO) session.getAttribute("memberInfo");
+        if (member == null) {
+            System.out.println("❌ [recommendedController] 세션에 memberInfo 없음 → 메인 페이지로");
+            return "redirect:/main";
+        }
+
+        String memberId = member.getMemberId();
+        System.out.println("✅ [recommendedController] 로그인된 memberId: " + memberId);
+
+        //공공 데이터 API 호출 // common 정보
+        try {
+            URI uri = UriComponentsBuilder
+                    .fromHttpUrl(BASE_API_URL_COMMON)
+                    .queryParam("serviceKey", SERVICE_KEY)
+                    .queryParam("MobileOS", "ETC")
+                    .queryParam("MobileApp", "AppTest")
+                    .queryParam("_type", "json")
+                    .queryParam("contentId", contentid)
+                    .queryParam("defaultYN", "Y")
+                    .queryParam("firstImageYN", "Y")
+                    .queryParam("areacodeYN", "Y")
+                    .queryParam("catcodeYN", "Y")
+                    .queryParam("addrinfoYN", "Y")
+                    .queryParam("mapinfoYN", "Y")
+                    .queryParam("overviewYN", "Y")
+                    .build(true) // true -> 기존 파라미터 그대로 (중복인코딩x)
+                    .toUri();
+            System.out.println("detailController 요청 URI:  " + uri);
+
+            //2. header 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+            headers.set("User-Agent", "Mozilla/5.0");
+
+            HttpEntity<?> entity = new HttpEntity<>(headers);
+
+            //3. 요청
+            ResponseEntity<String> response = restTemplate.exchange(
+                    uri,
+                    HttpMethod.GET,
+                    entity,
+                    String.class
+            );
+
+            //4. 응답 파싱
+//            response.getStatusCode();
+//            response.getHeaders();
+//            response.getBody();
+            System.out.println("✅ [recommendedController] 응답 상태: " + response.getStatusCode());
+            System.out.println("✅ [recommendedController] 응답 헤더: " + response.getHeaders());
+            String responseBody = response.getBody();
+            System.out.println("✅ [recommendedController] 응답 바디: " + responseBody);
+
+            if (response.getStatusCode() == HttpStatus.OK && responseBody != null) {
+                JSONObject jsonObj = new JSONObject(responseBody);
+
+                if (jsonObj.has("response")) {
+                    JSONObject respObj = jsonObj.getJSONObject("response");
+                    if (respObj.has("body")
+                            && respObj.getJSONObject("body").has("items")
+                            && respObj.getJSONObject("body").getJSONObject("items").has("item")) {
+
+                        JSONArray items = respObj
+                                .getJSONObject("body")
+                                .getJSONObject("items")
+                                .getJSONArray("item");
+                        model.addAttribute("items", items);
+                        System.out.println("✅ respone 완료 후 model에 items 추가");
+                    } else {
+                        System.out.println("❌ [recommendedController] 'item' 배열 없음.");
+                        model.addAttribute("items", new JSONArray());
+                    }
+                } else {
+                    System.out.println("❌ [recommendedController] 'response' 키 없음.");
+                    model.addAttribute("items", new JSONArray());
+                }
+            } else {
+                System.out.println("❌ [recommendedController] 응답 코드 200이 아니거나 바디가 null");
+                model.addAttribute("items", new JSONArray());
+            }
+
+        } catch (Exception e) {
+            System.out.println("❌ [recommendedController] 공공데이터 API 오류: " + e.getMessage());
+            e.printStackTrace();
+            model.addAttribute("items", new JSONArray());
+        }
+
+        // 여행지 detail정보
+        String detail = Detailintro(contentid, contenttypeid);
+        model.addAttribute("detail", detail);
+
+        //JSP에서 타입 분기를 위해 contenttypeid 자체도 넘김
+        model.addAttribute("contenttypeid", contenttypeid);
+
+
+        return "/recommended/detail";
+    }
+
+    // 여행지 detial 정보
+    private String Detailintro(String contentid, String contenttypeid) {
+        //공공 데이터 API 호출 // common 정보
+        try {
+            URI uri = UriComponentsBuilder
+                    .fromHttpUrl(BASE_API_URL_DETAIL)
+                    .queryParam("serviceKey", SERVICE_KEY)
+                    .queryParam("MobileOS", "ETC")
+                    .queryParam("MobileApp", "AppTest")
+                    .queryParam("_type", "json")
+                    .queryParam("contentId", contentid)
+                    .queryParam("contentTypeId", contenttypeid)
+                    .build(true)
+                    .toUri();
+
+            System.out.println("detailintro 요청 URI:  " + uri);
+
+            //헤더 설정.
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+            headers.set("User-Agent", "Mozilla/5.0");
+
+            HttpEntity<?> entity = new HttpEntity<>(headers);
+
+            //요청
+            ResponseEntity<String> response = restTemplate.exchange(
+                    uri,
+                    HttpMethod.GET,
+                    entity,
+                    String.class
+            );
+
+            //응답 파싱
+            response.getStatusCode();
+            response.getHeaders();
+//            response.getBody();
+            System.out.println("✅ [dtailintro] 응답 상태: " + response.getStatusCode());
+            System.out.println("✅ [dtailintro] 응답 헤더: " + response.getHeaders());
+            String responseBody = response.getBody();
+            System.out.println("✅ [dtailintro] 응답 바디: " + responseBody);
+
+            if (response.getStatusCode() == HttpStatus.OK && responseBody != null) {
+                JSONObject jsonObj = new JSONObject(responseBody);
+
+                if (jsonObj.has("response")) {
+                    JSONObject respObj = jsonObj.getJSONObject("response");
+                    if (respObj.has("body")
+                        && respObj.getJSONObject("body").has("items")
+                        && respObj.getJSONObject("body").getJSONObject("items").has("item")) {
+
+                        JSONArray items = respObj
+                                .getJSONObject("body")
+                                .getJSONObject("items")
+                                .getJSONArray("item");
+
+                        System.out.println("✅ JSON 배열을 문자열로 변환하여 반환");
+                        return items.toString();
+
+                    }
+                }
+            }
+
+        }catch (Exception e) {
+            System.out.println("❌ [detailintro] API 요청 중 오류 발생: " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        return "Detail 정보 없음";  // ✅ 반드시 return 필요!
+
+    }
+
+    @PostMapping("/recordClick")
+    public ResponseEntity<String> recordUserClick(
+            HttpSession session,
+            @RequestBody UserClickDTO userClickDTO
+    ) throws Exception {
+        MemberDTO member = (MemberDTO) session.getAttribute("memberInfo");
+        if (member != null) {
+            String memberId = member.getMemberId();
+            userClickDTO.setMember_id(memberId);
+            ifPreferenceService.clickTravelOne(userClickDTO);
+            System.out.println("[recordClick] " + userClickDTO);
+            return ResponseEntity.ok("Click recorded");
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("User not logged in");
+    }
+}

--- a/src/main/webapp/WEB-INF/views/auth/signup_result.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/signup_result.jsp
@@ -55,73 +55,73 @@
     <div class="row">
         <!-- 여행 분야 카드 -->
         <div class="col-12 col-md-3 mb-4">
-            <div class="card" onclick="selectCategory('자연 관광지', this)">
+            <div class="card" onclick="selectCategory('산', this)">
                 <div class="card-body">
-                    <h5 class="card-title">자연 관광지</h5>
+                    <h5 class="card-title">산</h5>
                     <p class="card-text">자연 속에서의 여행을 원하시면 선택하세요.</p>
                 </div>
             </div>
         </div>
 
         <div class="col-12 col-md-3 mb-4">
-            <div class="card" onclick="selectCategory('휴양 관광지', this)">
+            <div class="card" onclick="selectCategory('해안 절경', this)">
                 <div class="card-body">
-                    <h5 class="card-title">휴양 관광지</h5>
-                    <p class="card-text">편안하게 쉬고 싶은 여행을 원하시면 선택하세요.</p>
+                    <h5 class="card-title">해안 절경</h5>
+                    <p class="card-text">바다와 해안의 아름다움을 경험하고 싶다면 선택하세요.</p>
                 </div>
             </div>
         </div>
 
         <div class="col-12 col-md-3 mb-4">
-            <div class="card" onclick="selectCategory('역사 관광지', this)">
+            <div class="card" onclick="selectCategory('온천/욕장/스파', this)">
                 <div class="card-body">
-                    <h5 class="card-title">역사 관광지</h5>
-                    <p class="card-text">역사적인 장소를 탐방하는 여행을 원하시면 선택하세요.</p>
+                    <h5 class="card-title">온천/욕장/스파</h5>
+                    <p class="card-text">몸과 마음을 힐링할 수 있는 온천 및 스파 여행을 원하시면 선택하세요.</p>
                 </div>
             </div>
         </div>
 
         <div class="col-12 col-md-3 mb-4">
-            <div class="card" onclick="selectCategory('음식 탐방', this)">
+            <div class="card" onclick="selectCategory('카페/전통찻집', this)">
                 <div class="card-body">
-                    <h5 class="card-title">음식 탐방</h5>
-                    <p class="card-text">맛있는 음식을 즐기고 싶다면 선택하세요.</p>
+                    <h5 class="card-title">카페/전통찻집</h5>
+                    <p class="card-text">아늑한 분위기에서 커피와 차를 즐기고 싶다면 선택하세요.</p>
                 </div>
             </div>
         </div>
 
         <div class="col-12 col-md-3 mb-4">
-            <div class="card" onclick="selectCategory('육상 레포츠', this)">
+            <div class="card" onclick="selectCategory('복합 레포츠', this)">
                 <div class="card-body">
-                    <h5 class="card-title">육상 레포츠</h5>
-                    <p class="card-text">액티브한 운동을 즐기고 싶다면 선택하세요.</p>
+                    <h5 class="card-title">복합 레포츠</h5>
+                    <p class="card-text">다양한 레포츠를 한 번에 즐기고 싶다면 선택하세요.</p>
                 </div>
             </div>
         </div>
 
         <div class="col-12 col-md-3 mb-4">
-            <div class="card" onclick="selectCategory('문화시설', this)">
+            <div class="card" onclick="selectCategory('야영장,오토캠핑장', this)">
                 <div class="card-body">
-                    <h5 class="card-title">문화시설</h5>
-                    <p class="card-text">문화적인 경험을 원하는 분들을 위한 여행입니다.</p>
+                    <h5 class="card-title">야영장,오토캠핑장</h5>
+                    <p class="card-text">자연 속에서 캠핑과 야영을 즐기고 싶다면 선택하세요.</p>
                 </div>
             </div>
         </div>
 
         <div class="col-12 col-md-3 mb-4">
-            <div class="card" onclick="selectCategory('힐링 코스', this)">
+            <div class="card" onclick="selectCategory('문화관광축제', this)">
                 <div class="card-body">
-                    <h5 class="card-title">힐링 코스</h5>
-                    <p class="card-text">마음과 몸을 치유하는 여행을 원하시면 선택하세요.</p>
+                    <h5 class="card-title">문화관광축제</h5>
+                    <p class="card-text">다채로운 문화와 축제의 분위기를 경험하고 싶다면 선택하세요.</p>
                 </div>
             </div>
         </div>
 
         <div class="col-12 col-md-3 mb-4">
-            <div class="card" onclick="selectCategory('쇼핑', this)">
+            <div class="card" onclick="selectCategory('박물관', this)">
                 <div class="card-body">
-                    <h5 class="card-title">쇼핑</h5>
-                    <p class="card-text">쇼핑을 즐기고 싶다면 이 카드를 선택하세요.</p>
+                    <h5 class="card-title">박물관</h5>
+                    <p class="card-text">역사와 문화, 예술을 감상하고 싶다면 이 카드를 선택하세요.</p>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/views/recommended/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/recommended/detail.jsp
@@ -1,110 +1,185 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ page import="org.json.JSONArray" %>
 <%@ page import="org.json.JSONObject" %>
 <html>
 <head>
     <title>여행지 상세 정보</title>
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/layout/style.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"/>
     <style>
-        body {
-            font-family: Arial, sans-serif;
-        }
-        .container {
-            width: 80%;
-            margin: auto;
-        }
-        .title {
-            font-size: 24px;
-            font-weight: bold;
-            margin-top: 20px;
-        }
-        .image-container img {
-            width: 100%;
-            max-height: 400px;
-            object-fit: cover;
-        }
-        .details {
-            margin-top: 20px;
-        }
-        .info-box {
-            padding: 10px;
-            border: 1px solid #ddd;
-            margin-top: 10px;
-        }
+        body { font-family: Arial, sans-serif; }
+        .container { width: 80%; margin: 30px auto 50px auto; }
+        .title { font-size: 24px; font-weight: bold; margin-top: 20px; }
+        .image-container img { width: 100%; max-height: 400px; object-fit: cover; }
+        .details { margin-top: 20px; }
+        .info-box { padding: 10px; border: 1px solid #ddd; margin-top: 10px; }
+        .info-box h3 { margin-bottom: 10px; }
+        /* 지도 표시 영역 */
+        #map { width: 100%; height: 400px; margin-top: 20px; }
     </style>
 </head>
 <body>
+<!-- 공통 네비게이션 -->
+<jsp:include page="/WEB-INF/views/layout/nav.jsp" />
+
 <div class="container">
     <h1 class="title">여행지 상세 정보</h1>
+        <%
+            // 좌표를 포함한 기본 정보를 사용하기 위해 변수들을 미리 선언
+            String mapX = "";
+            String mapY = "";
+            String mlevel = "";
 
-    <%
-        JSONArray items = (JSONArray) request.getAttribute("items");
-        if (items != null && items.length() > 0) {
-            JSONObject item = items.getJSONObject(0); // 첫 번째 데이터만 표시
+            // 컨트롤러에서 전달받은 items 배열을 이용
+            JSONArray items = (JSONArray) request.getAttribute("items");
+            if (items != null && items.length() > 0) {
+                JSONObject item = items.getJSONObject(0);
 
-            // 기본 정보
-            String title = item.optString("title", "제목 없음");
-            String firstImage = item.optString("firstimage", "default.jpg");
-            String address = item.optString("addr1", "주소 정보 없음");
-            String overview = item.optString("overview", "상세 정보 없음");
-
-            // 추가 정보 (홈페이지 & 전화번호)
-            String homepage = item.optString("homepage", "").trim();
-            if (homepage.isEmpty()) {
-                homepage = "정보 없음";
-            }
-            String tel = item.optString("tel", "").trim();
-            if (tel.isEmpty()) {
-                tel = "정보 없음";
-            }
-
-            // 지도 좌표
-            String mapX = item.has("mapx") ? item.get("mapx").toString() : "정보 없음";
-            String mapY = item.has("mapy") ? item.get("mapy").toString() : "정보 없음";
-    %>
-
+                // 좌표 관련 값은 나중에 지도 초기화 시 사용
+                mapX = item.optString("mapx", "").trim();
+                mapY = item.optString("mapy", "").trim();
+                mlevel = item.optString("mlevel", "").trim();
+        %>
     <!-- 제목 -->
+        <%
+            String title = item.optString("title", "").trim();
+            if (!title.isEmpty()) {
+        %>
     <h2><%= title %></h2>
+        <%
+            }
+        %>
 
-    <!-- 이미지 영역 (오직 firstImage만 표시) -->
+    <!-- 이미지 -->
     <div class="image-container">
-        <img src="<%= firstImage %>" alt="여행지 이미지">
+        <%
+            String firstImage = item.optString("firstimage", "").trim();
+            if (!firstImage.isEmpty()) {
+        %>
+        <img src="<%= firstImage %>" alt="여행지 이미지" />
+        <%
+        } else {
+        %>
+        <img src="default.jpg" alt="기본 이미지" />
+        <%
+            }
+        %>
     </div>
 
-    <!-- 상세 정보 -->
+    <!-- 기본 정보 -->
     <div class="details">
+        <%
+            String address = item.optString("addr1", "").trim();
+            if (!address.isEmpty()) {
+        %>
         <div class="info-box">
             <h3>주소</h3>
             <p><%= address %></p>
         </div>
-
+        <%
+            }
+            String overview = item.optString("overview", "").trim();
+            if (!overview.isEmpty()) {
+        %>
         <div class="info-box">
             <h3>상세 설명</h3>
             <p><%= overview %></p>
         </div>
-
+        <%
+            }
+            String homepage = item.optString("homepage", "").trim();
+            if (!homepage.isEmpty()) {
+        %>
         <div class="info-box">
             <h3>홈페이지</h3>
-            <p><%= homepage %></p>
+            <p>
+                <a href="<%= homepage %>" target="_blank">
+                    <%= homepage %>
+                </a>
+            </p>
         </div>
-
+        <%
+            }
+            String tel = item.optString("tel", "").trim();
+            if (!tel.isEmpty()) {
+        %>
         <div class="info-box">
             <h3>전화번호</h3>
             <p><%= tel %></p>
         </div>
+        <%
+            }
+            // 지도 좌표 info-box는 제거합니다.
+        } else {
+        %>
+        <p>데이터를 불러오지 못했습니다.</p>
+        <%
+            }
+        %>
 
+        <!-- 지도 영역 제목 -->
         <div class="info-box">
-            <h3>지도 좌표</h3>
-            <p>X: <%= mapX %>, Y: <%= mapY %></p>
+            <h3>지도</h3>
+            <!-- 지도 영역 -->
+            <div id="map"></div>
+            <!-- Kakao Map API 스크립트 및 지도 초기화 -->
+            <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=1566bd1d6f68d1023bc9a09a03089078"></script>
+            <script>
+                <%
+                   // 좌표 값이 존재할 경우에만 지도 초기화
+                   if (!mapX.isEmpty() && !mapY.isEmpty() && !mlevel.isEmpty()) {
+                %>
+                // Kakao Map API는 위도(mapY), 경도(mapX) 순서입니다.
+                var container = document.getElementById('map');
+                var options = {
+                    center: new kakao.maps.LatLng(<%= mapY %>, <%= mapX %>),
+                    level: parseInt('<%= mlevel %>')
+                };
+                var map = new kakao.maps.Map(container, options);
+
+                // 마커 생성
+                var markerPosition = new kakao.maps.LatLng(<%= mapY %>, <%= mapX %>);
+                var marker = new kakao.maps.Marker({
+                    position: markerPosition
+                });
+                marker.setMap(map);
+                <% } %>
+            </script>
         </div>
+
+        <hr style="margin-top:40px; margin-bottom:40px;">
+
+        <!-- 타입별 추가 상세정보 include -->
+        <c:choose>
+            <c:when test="${contenttypeid == '12'}">
+                <jsp:include page="/WEB-INF/views/recommended/detail_type12.jsp" />
+            </c:when>
+            <c:when test="${contenttypeid == '14'}">
+                <jsp:include page="/WEB-INF/views/recommended/detail_type14.jsp" />
+            </c:when>
+            <c:when test="${contenttypeid == '15'}">
+                <jsp:include page="/WEB-INF/views/recommended/detail_type15.jsp" />
+            </c:when>
+            <c:when test="${contenttypeid == '25'}">
+                <jsp:include page="/WEB-INF/views/recommended/detail_type25.jsp" />
+            </c:when>
+            <c:when test="${contenttypeid == '28'}">
+                <jsp:include page="/WEB-INF/views/recommended/detail_type28.jsp" />
+            </c:when>
+            <c:when test="${contenttypeid == '39'}">
+                <jsp:include page="/WEB-INF/views/recommended/detail_type39.jsp" />
+            </c:when>
+            <c:otherwise>
+                <div class="info-box">
+                    <p>추가 상세 정보가 없습니다.</p>
+                </div>
+            </c:otherwise>
+        </c:choose>
     </div>
 
-    <%
-    } else {
-    %>
-    <p>데이터를 불러오지 못했습니다.</p>
-    <%
-        }
-    %>
-</div>
+    <!-- 공통 푸터 -->
+    <jsp:include page="/WEB-INF/views/layout/footer.jsp" />
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/recommended/detail_type12.jsp
+++ b/src/main/webapp/WEB-INF/views/recommended/detail_type12.jsp
@@ -1,0 +1,72 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page import="org.json.JSONArray" %>
+<%@ page import="org.json.JSONObject" %>
+<div class="info-box">
+    <h3>추가 상세 정보 (관광지)</h3>
+    <%
+        String detailStr = (String) request.getAttribute("detail");
+        if (detailStr != null && !"Detail 정보 없음".equals(detailStr)) {
+            try {
+                JSONArray detailArray = new JSONArray(detailStr);
+                if (detailArray.length() > 0) {
+                    JSONObject detailItem = detailArray.getJSONObject(0);
+                    String expguide = detailItem.optString("expguide", "").trim();
+                    String restdate = detailItem.optString("restdate", "").trim();
+                    String infocenter = detailItem.optString("infocenter", "").trim();
+                    String chkbabycarriage = detailItem.optString("chkbabycarriage", "").trim();
+                    String usetime = detailItem.optString("usetime", "").trim();
+                    String parking = detailItem.optString("parking", "").trim();
+
+                    if (!expguide.isEmpty()) {
+    %>
+    <p><strong>이용안내:</strong> <%= expguide %></p>
+    <%
+        }
+        if (!restdate.isEmpty()) {
+    %>
+    <p><strong>쉬는날:</strong> <%= restdate %></p>
+    <%
+        }
+        if (!infocenter.isEmpty()) {
+    %>
+    <p><strong>문의처:</strong> <%= infocenter %></p>
+    <%
+        }
+        if (!chkbabycarriage.isEmpty()) {
+    %>
+    <p><strong>유모차 대여:</strong> <%= chkbabycarriage %></p>
+    <%
+        }
+        if (!usetime.isEmpty()) {
+    %>
+    <p><strong>이용시간:</strong> <%= usetime %></p>
+    <%
+        }
+        if (!parking.isEmpty()) {
+    %>
+    <p><strong>주차시설:</strong> <%= parking %></p>
+    <%
+        }
+        if(expguide.isEmpty() && restdate.isEmpty() && infocenter.isEmpty()
+                && chkbabycarriage.isEmpty() && usetime.isEmpty() && parking.isEmpty()){
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    } else {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    } catch (Exception e) {
+    %>
+    <p>추가 상세 정보 파싱 중 오류 발생.</p>
+    <%
+        }
+    } else {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    %>
+</div>

--- a/src/main/webapp/WEB-INF/views/recommended/detail_type14.jsp
+++ b/src/main/webapp/WEB-INF/views/recommended/detail_type14.jsp
@@ -1,0 +1,65 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page import="org.json.JSONArray" %>
+<%@ page import="org.json.JSONObject" %>
+<div class="info-box">
+  <h3>추가 상세 정보 (문화시설)</h3>
+  <%
+    String detailStr = (String) request.getAttribute("detail");
+    if (detailStr != null && !"Detail 정보 없음".equals(detailStr)) {
+      try {
+        JSONArray detailArray = new JSONArray(detailStr);
+        if (detailArray.length() > 0) {
+          JSONObject detailItem = detailArray.getJSONObject(0);
+          String restdateCulture = detailItem.optString("restdateculture", "").trim();
+          String usefee = detailItem.optString("usefee", "").trim();
+          String spendtimeCulture = detailItem.optString("spendtimeculture", "").trim();
+          String scale = detailItem.optString("scale", "").trim();
+          String infocenterCulture = detailItem.optString("infocenterculture", "").trim();
+
+          if (!restdateCulture.isEmpty()) {
+  %>
+  <p><strong>쉬는날:</strong> <%= restdateCulture %></p>
+  <%
+    }
+    if (!usefee.isEmpty()) {
+  %>
+  <p><strong>이용요금:</strong> <%= usefee %></p>
+  <%
+    }
+    if (!spendtimeCulture.isEmpty()) {
+  %>
+  <p><strong>관람 소요시간:</strong> <%= spendtimeCulture %></p>
+  <%
+    }
+    if (!scale.isEmpty()) {
+  %>
+  <p><strong>규모:</strong> <%= scale %></p>
+  <%
+    }
+    if (!infocenterCulture.isEmpty()) {
+  %>
+  <p><strong>문의처:</strong> <%= infocenterCulture %></p>
+  <%
+    }
+    if(restdateCulture.isEmpty() && usefee.isEmpty() && spendtimeCulture.isEmpty() && scale.isEmpty() && infocenterCulture.isEmpty()){
+  %>
+  <p>추가 상세 정보가 없습니다.</p>
+  <%
+    }
+  } else {
+  %>
+  <p>추가 상세 정보가 없습니다.</p>
+  <%
+    }
+  } catch (Exception e) {
+  %>
+  <p>추가 상세 정보 파싱 중 오류 발생.</p>
+  <%
+    }
+  } else {
+  %>
+  <p>추가 상세 정보가 없습니다.</p>
+  <%
+    }
+  %>
+</div>

--- a/src/main/webapp/WEB-INF/views/recommended/detail_type15.jsp
+++ b/src/main/webapp/WEB-INF/views/recommended/detail_type15.jsp
@@ -1,0 +1,93 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page import="org.json.JSONArray" %>
+<%@ page import="org.json.JSONObject" %>
+<div class="info-box">
+    <h3>추가 상세 정보 (축제/공연/행사)</h3>
+    <%
+        String detailStr = (String) request.getAttribute("detail");
+        if (detailStr != null && !"Detail 정보 없음".equals(detailStr)) {
+            try {
+                JSONArray detailArray = new JSONArray(detailStr);
+                if (detailArray.length() > 0) {
+                    JSONObject detailItem = detailArray.getJSONObject(0);
+                    String agelimit = detailItem.optString("agelimit", "").trim();
+                    String discountinfo = detailItem.optString("discountinfofestival", "").trim();
+                    String eventstartdate = detailItem.optString("eventstartdate", "").trim();
+                    String eventenddate = detailItem.optString("eventenddate", "").trim();
+                    String eventplace = detailItem.optString("eventplace", "").trim();
+                    String festivalgrade = detailItem.optString("festivalgrade", "").trim();
+                    String spendtimeFestival = detailItem.optString("spendtimefestival", "").trim();
+                    String playtime = detailItem.optString("playtime", "").trim();
+                    String program = detailItem.optString("program", "").trim();
+                    String sponser1 = detailItem.optString("sponsor1", "").trim();
+                    String sponser1tel = detailItem.optString("sponsor1tel", "").trim();
+
+                    if (!agelimit.isEmpty()) {
+    %>
+    <p><strong>관람가능연령:</strong> <%= agelimit %></p>
+    <%
+        }
+        if (!discountinfo.isEmpty()) {
+    %>
+    <p><strong>할인정보:</strong> <%= discountinfo %></p>
+    <%
+        }
+        if (!eventstartdate.isEmpty() || !eventenddate.isEmpty()) {
+    %>
+    <p><strong>행사기간:</strong> <%= eventstartdate %> ~ <%= eventenddate %></p>
+    <%
+        }
+        if (!eventplace.isEmpty()) {
+    %>
+    <p><strong>행사장소:</strong> <%= eventplace %></p>
+    <%
+        }
+        if (!festivalgrade.isEmpty()) {
+    %>
+    <p><strong>축제등급:</strong> <%= festivalgrade %></p>
+    <%
+        }
+        if (!spendtimeFestival.isEmpty()) {
+    %>
+    <p><strong>관람 소요시간:</strong> <%= spendtimeFestival %></p>
+    <%
+        }
+        if (!playtime.isEmpty()) {
+    %>
+    <p><strong>공연시간:</strong> <%= playtime %></p>
+    <%
+        }
+        if (!program.isEmpty()) {
+    %>
+    <p><strong>프로그램:</strong> <%= program %></p>
+    <%
+        }
+        if (!sponser1.isEmpty() || !sponser1tel.isEmpty()) {
+    %>
+    <p><strong>주최자/문의:</strong> <%= sponser1 %> <%= sponser1tel %></p>
+    <%
+        }
+        if (agelimit.isEmpty() && discountinfo.isEmpty() && eventstartdate.isEmpty() && eventenddate.isEmpty() &&
+                eventplace.isEmpty() && festivalgrade.isEmpty() && spendtimeFestival.isEmpty() &&
+                playtime.isEmpty() && program.isEmpty() && sponser1.isEmpty() && sponser1tel.isEmpty()) {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    } else {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    } catch (Exception e) {
+    %>
+    <p>추가 상세 정보 파싱 중 오류 발생.</p>
+    <%
+        }
+    } else {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    %>
+</div>

--- a/src/main/webapp/WEB-INF/views/recommended/detail_type25.jsp
+++ b/src/main/webapp/WEB-INF/views/recommended/detail_type25.jsp
@@ -1,0 +1,59 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page import="org.json.JSONArray" %>
+<%@ page import="org.json.JSONObject" %>
+<div class="info-box">
+    <h3>추가 상세 정보 (여행코스)</h3>
+    <%
+        String detailStr = (String) request.getAttribute("detail");
+        if (detailStr != null && !"Detail 정보 없음".equals(detailStr)) {
+            try {
+                JSONArray detailArray = new JSONArray(detailStr);
+                if (detailArray.length() > 0) {
+                    JSONObject detailItem = detailArray.getJSONObject(0);
+                    String distance = detailItem.optString("distance", "").trim();
+                    String taketime = detailItem.optString("taketime", "").trim();
+                    String infocentertourcourse = detailItem.optString("infocentertourcourse", "").trim();
+                    String schedule = detailItem.optString("schedule", "").trim();
+
+                    if (!distance.isEmpty()) {
+    %>
+    <p><strong>총 거리:</strong> <%= distance %></p>
+    <%
+        }
+        if (!taketime.isEmpty()) {
+    %>
+    <p><strong>소요시간:</strong> <%= taketime %></p>
+    <%
+        }
+        if (!infocentertourcourse.isEmpty()) {
+    %>
+    <p><strong>문의처:</strong> <%= infocentertourcourse %></p>
+    <%
+        }
+        if (!schedule.isEmpty()) {
+    %>
+    <p><strong>추천 일정:</strong> <%= schedule %></p>
+    <%
+        }
+        if(distance.isEmpty() && taketime.isEmpty() && infocentertourcourse.isEmpty() && schedule.isEmpty()){
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    } else {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    } catch (Exception e) {
+    %>
+    <p>추가 상세 정보 파싱 중 오류 발생.</p>
+    <%
+        }
+    } else {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    %>
+</div>

--- a/src/main/webapp/WEB-INF/views/recommended/detail_type28.jsp
+++ b/src/main/webapp/WEB-INF/views/recommended/detail_type28.jsp
@@ -1,0 +1,78 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page import="org.json.JSONArray" %>
+<%@ page import="org.json.JSONObject" %>
+<div class="info-box">
+    <h3>추가 상세 정보 (레포츠)</h3>
+    <%
+        String detailStr = (String) request.getAttribute("detail");
+        if (detailStr != null && !"Detail 정보 없음".equals(detailStr)) {
+            try {
+                JSONArray detailArray = new JSONArray(detailStr);
+                if (detailArray.length() > 0) {
+                    JSONObject detailItem = detailArray.getJSONObject(0);
+                    String infocenterLeports = detailItem.optString("infocenterleports", "").trim();
+                    String restdateLeports   = detailItem.optString("restdateleports", "").trim();
+                    String usefeeleports     = detailItem.optString("usefeeleports", "").trim();
+                    String expagerangeleports= detailItem.optString("expagerangeleports", "").trim();
+                    String accomcountleports = detailItem.optString("accomcountleports", "").trim();
+                    String usetimeleports    = detailItem.optString("usetimeleports", "").trim();
+                    String parkingleports    = detailItem.optString("parkingleports", "").trim();
+
+                    if (!infocenterLeports.isEmpty()) {
+    %>
+    <p><strong>문의처:</strong> <%= infocenterLeports %></p>
+    <%
+        }
+        if (!restdateLeports.isEmpty()) {
+    %>
+    <p><strong>쉬는날:</strong> <%= restdateLeports %></p>
+    <%
+        }
+        if (!usefeeleports.isEmpty()) {
+    %>
+    <p><strong>이용요금:</strong> <%= usefeeleports %></p>
+    <%
+        }
+        if (!expagerangeleports.isEmpty()) {
+    %>
+    <p><strong>이용가능연령:</strong> <%= expagerangeleports %></p>
+    <%
+        }
+        if (!accomcountleports.isEmpty()) {
+    %>
+    <p><strong>수용인원:</strong> <%= accomcountleports %></p>
+    <%
+        }
+        if (!usetimeleports.isEmpty()) {
+    %>
+    <p><strong>이용시간:</strong> <%= usetimeleports %></p>
+    <%
+        }
+        if (!parkingleports.isEmpty()) {
+    %>
+    <p><strong>주차시설:</strong> <%= parkingleports %></p>
+    <%
+        }
+        if (infocenterLeports.isEmpty() && restdateLeports.isEmpty() && usefeeleports.isEmpty() &&
+                expagerangeleports.isEmpty() && accomcountleports.isEmpty() && usetimeleports.isEmpty() && parkingleports.isEmpty()) {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    } else {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    } catch (Exception e) {
+    %>
+    <p>추가 상세 정보 파싱 중 오류 발생.</p>
+    <%
+        }
+    } else {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    %>
+</div>

--- a/src/main/webapp/WEB-INF/views/recommended/detail_type39.jsp
+++ b/src/main/webapp/WEB-INF/views/recommended/detail_type39.jsp
@@ -1,0 +1,72 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page import="org.json.JSONArray" %>
+<%@ page import="org.json.JSONObject" %>
+<div class="info-box">
+    <h3>추가 상세 정보 (음식)</h3>
+    <%
+        String detailStr = (String) request.getAttribute("detail");
+        if (detailStr != null && !"Detail 정보 없음".equals(detailStr)) {
+            try {
+                JSONArray detailArray = new JSONArray(detailStr);
+                if (detailArray.length() > 0) {
+                    JSONObject detailItem = detailArray.getJSONObject(0);
+                    String opentimefood = detailItem.optString("opentimefood", "").trim();
+                    String restdatefood = detailItem.optString("restdatefood", "").trim();
+                    String packing = detailItem.optString("packing", "").trim();
+                    String treatmenu = detailItem.optString("treatmenu", "").trim();
+                    String firstmenu = detailItem.optString("firstmenu", "").trim();
+                    String infocenterfood = detailItem.optString("infocenterfood", "").trim();
+
+                    if (!opentimefood.isEmpty()) {
+    %>
+    <p><strong>영업시간:</strong> <%= opentimefood %></p>
+    <%
+        }
+        if (!restdatefood.isEmpty()) {
+    %>
+    <p><strong>휴무일:</strong> <%= restdatefood %></p>
+    <%
+        }
+        if (!packing.isEmpty()) {
+    %>
+    <p><strong>포장 가능 여부:</strong> <%= packing %></p>
+    <%
+        }
+        if (!treatmenu.isEmpty()) {
+    %>
+    <p><strong>취급 메뉴:</strong> <%= treatmenu %></p>
+    <%
+        }
+        if (!firstmenu.isEmpty()) {
+    %>
+    <p><strong>대표 메뉴:</strong> <%= firstmenu %></p>
+    <%
+        }
+        if (!infocenterfood.isEmpty()) {
+    %>
+    <p><strong>문의처:</strong> <%= infocenterfood %></p>
+    <%
+        }
+        if(opentimefood.isEmpty() && restdatefood.isEmpty() && packing.isEmpty() &&
+                treatmenu.isEmpty() && firstmenu.isEmpty() && infocenterfood.isEmpty()){
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    } else {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    } catch (Exception e) {
+    %>
+    <p>추가 상세 정보 파싱 중 오류 발생.</p>
+    <%
+        }
+    } else {
+    %>
+    <p>추가 상세 정보가 없습니다.</p>
+    <%
+        }
+    %>
+</div>


### PR DESCRIPTION
- 제목 : feature/recommended-fe-be 사용자 맞춤 여행지 추천 로직 수정 및 여행지 세부정보 view 수정


## 🔘Part

- [FE/BE ✅] 추천 페이지 UI 및 API 연동  
  - 사용자가 추천 여행지를 확인할 수 있도록 UI를 개선하고, 백엔드 API와 연동하여 데이터를 가져옴

- [BE ✅] 사용자 선호도 DB 연동 및 저장  
  - 사용자 클릭 데이터를 기반으로 선호도를 DB에 저장하여 추천 알고리즘에 반영

- [FE/BE ✅] 사용자 여행지 클릭 기반 맞춤 여행지 추천  
  - 클릭 기록을 바탕으로 추천 로직을 수정하고, FastAPI를 사용하고 공공데이터 api 사용하여 상세정보 뷰를 업데이트함

- [FE/BE ✅] 여행지 관련 맵핑 정보를 활용한 지도 API 연동 및 위치 출력  
  - 공공데이터 API로부터 받은 좌표 정보를 활용하여, Kakao Map API 연동을 통해 여행지 위치를 지도에 시각화함
  - 
  <br/>

## 🔎 작업 내용

추천 페이지 UI 및 API 연동

-✅ 추천 페이지 UI를 개선했음. 사용자가 추천 여행지를 쉽게 확인할 수 있도록 디자인 수정 완료했음.
       백엔드 API와 연동해 데이터를 동적으로 불러오도록 구현했음.
       사용자 선호도 DB 연동 및 저장

-✅ 사용자 클릭 데이터를 DB에 저장하도록 로직 구현했음.
       저장된 데이터를 기반으로 추천 알고리즘에 사용자 선호도를 반영하도록 처리했음.
       원래 사용자가 가입할때 선택하는 선호도는 cat2의 데이터 였는데 오늘 cat3로 바꿧음.
       사용자 여행지 클릭 기반 맞춤 여행지 추천

-✅ 사용자 클릭 기록을 분석해 맞춤형 추천 로직을 수정했음.
       FastAPI와 공공데이터 API를 사용해 여행지 상세정보 뷰를 업데이트했음.
       contenttypeid(관광지(12), 문화시설(14) 별로 response 되는 필드가 달라서 그거에 맞게 수정하고 jsp 분리함.
 
-✅공공데이터 API에서 받은 좌표 정보를 활용해 Kakao Map API 연동했음.
      지도 영역에 '지도'라는 제목 하에 실제 여행지 위치를 시각화하는 기능을 구현했음.

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/51d339a0-2745-404f-9c0a-4dbf32c81f2f)
![image](https://github.com/user-attachments/assets/576f06bf-e89d-4704-94b3-2676ed6e5899)

<br/>

## 🔧 앞으로의 과제

- 사용자 맞춘 여행지 추천하는 로직을 더 매끄럽게 수정할 예정
- 문화 축제 탭도 수정하고 추천 여행코스 탭도 추가할 예정
  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>